### PR TITLE
fix: remove is required in prop types (PrevArrow, NextArrow)

### DIFF
--- a/src/components/Slider/index.js
+++ b/src/components/Slider/index.js
@@ -29,7 +29,7 @@ const NextArrow = (props) => {
 }
 
 NextArrow.propTypes = {
-  onClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func,
 }
 
 const PrevArrow = (props) => {
@@ -54,7 +54,7 @@ const PrevArrow = (props) => {
 }
 
 PrevArrow.propTypes = {
-  onClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func,
 }
 
 const AppendDots = (dots) => {


### PR DESCRIPTION
This validation show  a error in console using with next.js

![image](https://user-images.githubusercontent.com/3749401/107969887-22d01200-6f8f-11eb-9266-4ff847ca841c.png)

In this line is create this component without pass props onClick
https://github.com/prismicio/essential-slices/blob/00ddce1716dedcde63c765121ba86f9d3ea42458/src/components/Slider/index.js#L85
https://github.com/prismicio/essential-slices/blob/00ddce1716dedcde63c765121ba86f9d3ea42458/src/components/Slider/index.js#L86
